### PR TITLE
Feat. 비디오에서 프레임 추출 기능 개발

### DIFF
--- a/routes/controllers/videoFrame.controller.js
+++ b/routes/controllers/videoFrame.controller.js
@@ -1,0 +1,32 @@
+const fs = require("fs");
+const path = require("path");
+
+const convertPath = require("../../services/convertPath");
+const extractFramesFromVideo = require("../../services/extractFramesFromVideo");
+
+exports.videoToFrame = function (req, res, next) {
+  const tempDirectory = path.join(__dirname, "../../temp");
+  const videoTotalPathList = Object.entries(req.body.videoUrlList);
+  const startPointsList = Object.values(req.body.startPoints);
+
+  videoTotalPathList.forEach(([folderPath, filePath], index) => {
+    const videoPath = path.join(
+      tempDirectory,
+      `videos/${convertPath(folderPath)}/${filePath}`,
+    );
+    const framesFolderPath = path.join(
+      tempDirectory,
+      `frames/${convertPath(folderPath)}`,
+    );
+    const startTime = startPointsList[index];
+
+    if (!fs.existsSync(framesFolderPath)) {
+      fs.mkdirSync(framesFolderPath, { recursive: true });
+    }
+
+    extractFramesFromVideo(videoPath, framesFolderPath, startTime, 1);
+  });
+
+  // TO DO: 여기에서, 응답이 아닌 다음 프로세스 컨트롤러를 연결해야 합니다.
+  console.log("complete!");
+};

--- a/routes/controllers/videoFrame.controller.js
+++ b/routes/controllers/videoFrame.controller.js
@@ -4,29 +4,49 @@ const path = require("path");
 const convertPath = require("../../services/convertPath");
 const extractFramesFromVideo = require("../../services/extractFramesFromVideo");
 
-exports.videoToFrame = function (req, res, next) {
-  const tempDirectory = path.join(__dirname, "../../temp");
-  const videoTotalPathList = Object.entries(req.body.videoUrlList);
-  const startPointsList = Object.values(req.body.startPoints);
+exports.videoToFrame = async function (req, res, next) {
+  try {
+    const tempDirectory = path.join(__dirname, "../../temp");
+    const videoTotalPathList = Object.entries(req.body.videoUrls);
+    const startPointsList = Object.values(req.body.startPoints);
 
-  videoTotalPathList.forEach(([folderPath, filePath], index) => {
-    const videoPath = path.join(
-      tempDirectory,
-      `videos/${convertPath(folderPath)}/${filePath}`,
+    const videoPromiseLists = videoTotalPathList.map(
+      ([folderPath, filePath], index) => {
+        const videoPath = path.join(
+          tempDirectory,
+          `videos/${convertPath(folderPath)}/${filePath}`,
+        );
+        const framesFolderPath = path.join(
+          tempDirectory,
+          `frames/${convertPath(folderPath)}`,
+        );
+        const startTime = startPointsList[index];
+
+        if (!fs.existsSync(framesFolderPath)) {
+          fs.mkdirSync(framesFolderPath, { recursive: true });
+        }
+
+        if (convertPath(folderPath) === "main-contents") {
+          return extractFramesFromVideo(
+            videoPath,
+            framesFolderPath,
+            startTime,
+            30,
+          );
+        }
+        return extractFramesFromVideo(
+          videoPath,
+          framesFolderPath,
+          startTime,
+          1,
+        );
+      },
     );
-    const framesFolderPath = path.join(
-      tempDirectory,
-      `frames/${convertPath(folderPath)}`,
-    );
-    const startTime = startPointsList[index];
 
-    if (!fs.existsSync(framesFolderPath)) {
-      fs.mkdirSync(framesFolderPath, { recursive: true });
-    }
-
-    extractFramesFromVideo(videoPath, framesFolderPath, startTime, 1);
-  });
-
+    // TO DO: 프로미스 배열 상태확인 후 reject 있을 시 에러 처리 필요
+    await Promise.allSettled(videoPromiseLists);
+  } catch (err) {
+    console.error(err);
+  }
   // TO DO: 여기에서, 응답이 아닌 다음 프로세스 컨트롤러를 연결해야 합니다.
-  console.log("complete!");
 };

--- a/routes/controllers/videoFrame.controller.js
+++ b/routes/controllers/videoFrame.controller.js
@@ -7,10 +7,10 @@ const extractFramesFromVideo = require("../../services/extractFramesFromVideo");
 exports.videoToFrame = async function (req, res, next) {
   try {
     const tempDirectory = path.join(__dirname, "../../temp");
-    const videoTotalPathList = Object.entries(req.body.videoUrls);
-    const startPointsList = Object.values(req.body.startPoints);
+    const videoPathList = Object.entries(req.body.videoUrls);
+    const startPointList = Object.values(req.body.startPoints);
 
-    const videoPromiseLists = videoTotalPathList.map(
+    const videoPromiseLists = videoPathList.map(
       ([folderPath, filePath], index) => {
         const videoPath = path.join(
           tempDirectory,
@@ -20,7 +20,7 @@ exports.videoToFrame = async function (req, res, next) {
           tempDirectory,
           `frames/${convertPath(folderPath)}`,
         );
-        const startTime = startPointsList[index];
+        const startTime = startPointList[index];
 
         if (!fs.existsSync(framesFolderPath)) {
           fs.mkdirSync(framesFolderPath, { recursive: true });

--- a/services/convertPath.js
+++ b/services/convertPath.js
@@ -1,0 +1,20 @@
+function convertPath(key) {
+  switch (key) {
+    case "mainVideoUrl":
+    case "mainAudioUrl":
+      return "main-contents";
+
+    case "firstSubVideoUrl":
+    case "firstSubAudioUrl":
+      return "sub-one-contents";
+
+    case "lastSubVideoUrl":
+    case "lastSubAudioUrl":
+      return "sub-two-contents";
+
+    default:
+      return null;
+  }
+}
+
+module.exports = convertPath;

--- a/services/extractFramesFromVideo.js
+++ b/services/extractFramesFromVideo.js
@@ -1,33 +1,42 @@
 const { spawn } = require("child_process");
 const path = require("path");
 
-function extractFramesFromVideo(inputPath, framePath, startSecond, fps) {
-  const ffmpegProcess = spawn("ffmpeg", [
-    "-i",
-    inputPath,
-    "-vf",
-    `fps=${fps}`,
-    "-ss",
-    startSecond,
-    "-start_number",
-    "1",
-    path.join(framePath, `frame_%d.jpg`),
-  ]);
+async function extractFramesFromVideo(inputPath, framePath, startSecond, fps) {
+  return new Promise((resolve, reject) => {
+    const ffmpegProcess = spawn("ffmpeg", [
+      "-i",
+      inputPath,
+      "-vf",
+      `fps=${fps}`,
+      "-ss",
+      startSecond,
+      "-start_number",
+      "1",
+      path.join(framePath, `frame_%d.jpg`),
+    ]);
 
-  ffmpegProcess.stdout.on("data", (data) => {
-    console.log(`stdout: ${data}`);
-  });
+    ffmpegProcess.stdout.on("data", (data) => {
+      console.log(`stdout: ${data}`);
+    });
 
-  ffmpegProcess.stderr.on("data", (data) => {
-    console.error(`stdout: ${data}`);
-  });
+    ffmpegProcess.stderr.on("data", (data) => {
+      console.error(`stderr: ${data}`);
+    });
 
-  ffmpegProcess.on("close", (code) => {
-    console.log(`child process exited with code ${code}`);
-  });
+    ffmpegProcess.on("close", (code) => {
+      if (code === 0) {
+        console.log("Frame extraction completed successfully");
+        resolve();
+      } else {
+        console.error(`Error: ffmpeg process exited with code ${code}`);
+        reject();
+      }
+    });
 
-  ffmpegProcess.on("error", (err) => {
-    console.error(`Error: ${err.message}`);
+    ffmpegProcess.on("error", (err) => {
+      console.error(`Error: ${err.message}`);
+      reject();
+    });
   });
 }
 

--- a/services/extractFramesFromVideo.js
+++ b/services/extractFramesFromVideo.js
@@ -1,6 +1,7 @@
 const { spawn } = require("child_process");
 const path = require("path");
 
+// TO DO: ffmpeg에 전달하는 배열인수를 반환하는 함수(duration 옵션 추가 등)
 async function extractFramesFromVideo(inputPath, framePath, startSecond, fps) {
   return new Promise((resolve, reject) => {
     const ffmpegProcess = spawn("ffmpeg", [

--- a/services/extractFramesFromVideo.js
+++ b/services/extractFramesFromVideo.js
@@ -1,0 +1,34 @@
+const { spawn } = require("child_process");
+const path = require("path");
+
+function extractFramesFromVideo(inputPath, framePath, startSecond, fps) {
+  const ffmpegProcess = spawn("ffmpeg", [
+    "-i",
+    inputPath,
+    "-vf",
+    `fps=${fps}`,
+    "-ss",
+    startSecond,
+    "-start_number",
+    "1",
+    path.join(framePath, `frame_%d.jpg`),
+  ]);
+
+  ffmpegProcess.stdout.on("data", (data) => {
+    console.log(`stdout: ${data}`);
+  });
+
+  ffmpegProcess.stderr.on("data", (data) => {
+    console.error(`stdout: ${data}`);
+  });
+
+  ffmpegProcess.on("close", (code) => {
+    console.log(`child process exited with code ${code}`);
+  });
+
+  ffmpegProcess.on("error", (err) => {
+    console.error(`Error: ${err.message}`);
+  });
+}
+
+module.exports = extractFramesFromVideo;

--- a/services/extractFramesFromVideo.js
+++ b/services/extractFramesFromVideo.js
@@ -12,8 +12,8 @@ async function extractFramesFromVideo(inputPath, framePath, startSecond, fps) {
       "-ss",
       startSecond,
       "-start_number",
-      "1",
-      path.join(framePath, `frame_%d.jpg`),
+      "0",
+      path.join(framePath, `frame_${fps}fps_%d.jpg`),
     ]);
 
     ffmpegProcess.stdout.on("data", (data) => {


### PR DESCRIPTION
# KanBan Title
- [[Server]  compliations POST 영상 프레임 추출 구현](https://www.notion.so/minsug/Server-compliations-POST-784fa445e460481091bbbb0ad6a4b9a6?pvs=4)

# Tasks in detail - checkList
- [x]  사용자로부터 입력받은 시작점을 옵션으로 하여, 영상을 *30fps/1fps* 프레임 추출합니다.
- [x]  우선 중심이 되는 메인 영상, 서브 영상 2개를 받아왔다는 전제 하에 1fps를 추출하도록 작성
- [x]  프레임 추출이 완료시 각 영상에 맞는 폴더에 업로드 완료
- [x]  메인 영상 1개에 대하여 시작점(`start time`)부터 30fps로 프레임을 추출
- [ ]  30fps로 추출하는 과정에서 1fps에 해당하는 프레임 이미지들을 별도로 키값을 설정해 업로드 
⇒ 이는 추후 [이어지는 칸반](https://www.notion.so/Server-compliations-POST-fab58d11a9b0471590c2486fe7cfff39?pvs=21)에서 작업할 예정입니다.

# Description
메인 영상에 대해 기본 프레임(30fps) 및 비교 분석용 프레임(1fps)을 추출하는 작업입니다.
30fps 프레임은 영상 편집 및 합성, 1fps는 영상 편집구간을 설정하기 위한 비교분석 알고리즘의 수행의 용도를 위해 추출합니다.

영상을 분석 후 합성하는 과정에 있어서 
1. 직접 `ffmpeg` 로 영상을 편집하는 방법과 
2. `ffmpeg`로 프레임 즉 이미지를 동영상으로 편집하는 과정을 비교해보고,
두번째 선택안인 프레임(이미지)합성의 속도가 더욱 빠른 것을 확인한 후 해당 작업을 진행하였습니다.

해당 과정에서는 프레임을 추출할 영상의 경로와 추출한 프레임을 넣어 줄 경로를 매개변수로 받고,
추출할 프레임 값을 함수도 매개변수로 지정할 수 있도록 하였습니다.

현재는 모든 요소에 대해 1fps로 추출하도록 지정한 상태이나
추후 필요에 따라 main 영상의 30fps가 필요하다면 
`req.body.videoUrls`객체의 key 값을 확인하여 매개변수 `fps`를 30으로 전달,
서브 영상의 1fps가 필요하다면 key 값을 확인하여 매개변수 `fps`를 1로 전달하여 
원하는 경로로 추출하도록 합니다.

# Concern
기존의 Key값 네이밍 컨벤션은 아래와 같았으나 
_ex. mainVideo_30fps_0030 , mainVideo_1fps_0030_
1fps 추가 추출 과정 없이 진행할 예정이며 비디오는 경로가 지정 되므로
편의를 위해 파일명에 명명하지 않았습니다.

# remarks
- [칸반링크](https://www.notion.so/minsug/Server-compliations-POST-784fa445e460481091bbbb0ad6a4b9a6?pvs=4)에 req.body mock data를 추가해두었고 주석으로 토글할 수 있도록 해두었습니다.

# 주의 사항
- [x] PR 크기는 300~500줄로 하되 최대 1000줄 미만으로 합니다.
- [x] conflict를 모두 해결하고 PR을 올려주세요


# PR 전 체크리스트
- [x] 가장 최신 브랜치를 pull 하였습니다
- [x] base 브랜치명을 확인하였습니다
- [x] 코드 컨벤션을 모두 확인하였습니다
- [x] 브랜치명을 확인하였습니다.
- [x] 작업 중 dependency 변경사항이 있는 경우 안내해주세요!