### PR TITLE
Feat. 원샷 프레임 분류 및 일치율 분석

### DIFF
--- a/routes/controllers/chooseFrame.controller.js
+++ b/routes/controllers/chooseFrame.controller.js
@@ -1,0 +1,34 @@
+const validateArrays = require("../../util/validateArrays");
+const sortCommonFrames = require("../../util/sortCommonFrames");
+const getMatchedPercent = require("../../util/getMatchedPercent");
+const convertFrameToBinaryArray = require("../../services/convertFrameToBinaryArray");
+
+// To Do 매개변수 재설정 - 현재 임의로 설정됨
+async function chooseFrame(mainFrames, subOneFrames, subTwoFrames) {
+  validateArrays(mainFrames, subOneFrames, subTwoFrames);
+
+  const { doubleOverlappedFrames, subOneSingleShots, subTwoSingleShots } =
+    sortCommonFrames(mainFrames, subOneFrames, subTwoFrames);
+
+  await Promise.all(
+    doubleOverlappedFrames.map(async (frameNumber) => {
+      const [mainBinary, subOneBinary, subTwoBinary] =
+        await convertFrameToBinaryArray(frameNumber);
+      const subOnePercent = getMatchedPercent(mainBinary, subOneBinary);
+      const subTwoPercent = getMatchedPercent(mainBinary, subTwoBinary);
+
+      if (subOnePercent >= subTwoPercent) {
+        subOneSingleShots.push(frameNumber);
+      } else {
+        subTwoSingleShots.push(frameNumber);
+      }
+    }),
+  );
+
+  subOneSingleShots.sort((a, b) => a - b);
+  subTwoSingleShots.sort((a, b) => a - b);
+
+  return { subOneSingleShots, subTwoSingleShots };
+}
+
+module.exports = chooseFrame;

--- a/routes/controllers/chooseFrame.controller.js
+++ b/routes/controllers/chooseFrame.controller.js
@@ -1,23 +1,29 @@
 const validateArrays = require("../../util/validateArrays");
-const sortCommonFrames = require("../../util/sortCommonFrames");
+const filterFramesByTwoSubs = require("../../util/filterFramesByTwoSubs");
 const getMatchedPercent = require("../../util/getMatchedPercent");
 const convertFrameToBinaryArray = require("../../services/convertFrameToBinaryArray");
 
-// To Do 매개변수 재설정 - 현재 임의로 설정됨
+// To Do 매개변수 재설정 및 에러 핸들링- 현재 임의로 설정됨
 async function chooseFrame(mainFrames, subOneFrames, subTwoFrames) {
   validateArrays(mainFrames, subOneFrames, subTwoFrames);
 
   const { doubleOverlappedFrames, subOneSingleShots, subTwoSingleShots } =
-    sortCommonFrames(mainFrames, subOneFrames, subTwoFrames);
+    filterFramesByTwoSubs(mainFrames, subOneFrames, subTwoFrames);
 
   await Promise.all(
     doubleOverlappedFrames.map(async (frameNumber) => {
-      const [mainBinary, subOneBinary, subTwoBinary] =
+      const [mainPixelBinary, subOnePixelBinary, subTwoPixelBinary] =
         await convertFrameToBinaryArray(frameNumber);
-      const subOnePercent = getMatchedPercent(mainBinary, subOneBinary);
-      const subTwoPercent = getMatchedPercent(mainBinary, subTwoBinary);
+      const subOneMatchRate = getMatchedPercent(
+        mainPixelBinary,
+        subOnePixelBinary,
+      );
+      const subTwoMatchRate = getMatchedPercent(
+        mainPixelBinary,
+        subTwoPixelBinary,
+      );
 
-      if (subOnePercent >= subTwoPercent) {
+      if (subOneMatchRate >= subTwoMatchRate) {
         subOneSingleShots.push(frameNumber);
       } else {
         subTwoSingleShots.push(frameNumber);

--- a/services/convertFrameToBinaryArray.js
+++ b/services/convertFrameToBinaryArray.js
@@ -1,0 +1,33 @@
+/* eslint-disable */
+const path = require("path");
+const sharp = require("sharp");
+
+async function convertFrameToBinaryArray(imageNumber) {
+  // To DO 수진님 코드 머지되면 상수처리된 path 사용해서 코드 길이 줄이기
+  const mainFramePath = path.join(__dirname, `../temp/difference/main-contents/difference_${imageNumber}.jpg`);
+  const subOneFramePath = path.join(__dirname, `../temp/difference/sub-one-contents/difference_${imageNumber}.jpg`);
+  const subTwoFramePath = path.join(__dirname, `../temp/difference/sub-two-contents/difference_${imageNumber}.jpg`);
+
+  const pathList = [mainFramePath, subOneFramePath, subTwoFramePath].map(async (framePath) => {
+    const { data, info } = await sharp(framePath)
+      .raw()
+      .toBuffer({ resolveWithObject: true });
+
+    const binaryArray = new Array(info.height).fill(null).map(() => new Array(info.width).fill(0));
+
+    for (let y = 0; y < info.height; y += 1) {
+      for (let x = 0; x < info.width; x += 1) {
+        const index = (y * info.width + x) * info.channels;
+        binaryArray[y][x] = data[index] === 0 ? 0 : 1;
+      }
+    }
+
+    return binaryArray.flat();
+  });
+
+  const binaryArrayList = await Promise.all(pathList);
+
+  return binaryArrayList;
+}
+
+module.exports = convertFrameToBinaryArray;

--- a/services/convertFrameToBinaryArray.js
+++ b/services/convertFrameToBinaryArray.js
@@ -13,16 +13,13 @@ async function convertFrameToBinaryArray(imageNumber) {
       .raw()
       .toBuffer({ resolveWithObject: true });
 
-    const binaryArray = new Array(info.height).fill(null).map(() => new Array(info.width).fill(0));
+    const binaryArray = new Array(info.height * info.width).fill(1);
 
-    for (let y = 0; y < info.height; y += 1) {
-      for (let x = 0; x < info.width; x += 1) {
-        const index = (y * info.width + x) * info.channels;
-        binaryArray[y][x] = data[index] === 0 ? 0 : 1;
-      }
+    for (let i = 0; i < data.length; i += info.channels) {
+      binaryArray[Math.floor(i / info.channels)] = data[i] === 0 ? 0 : 1;
     }
 
-    return binaryArray.flat();
+    return binaryArray;
   });
 
   const binaryArrayList = await Promise.all(pathList);

--- a/util/filterFramesByTwoSubs.js
+++ b/util/filterFramesByTwoSubs.js
@@ -3,35 +3,27 @@ const validateArrays = require("./validateArrays");
 function filterFramesByTwoSubs(mainFrames, subOneFrames, subTwoFrames) {
   validateArrays(mainFrames, subOneFrames, subTwoFrames);
 
-  const doubleOverlappedFrames = mainFrames.filter((imageNumber) => {
-    const hasSubOneSameFrame = subOneFrames.includes(imageNumber);
-    const hasSubTwoSameFrame = subTwoFrames.includes(imageNumber);
+  const doubleOverlappedFrames = [];
+  const subOneOverlappedFrames = [];
+  const subTwoOverlappedFrames = [];
+
+  mainFrames.forEach((frameNumber) => {
+    const hasSubOneSameFrame = subOneFrames.includes(frameNumber);
+    const hasSubTwoSameFrame = subTwoFrames.includes(frameNumber);
 
     if (hasSubOneSameFrame && hasSubTwoSameFrame) {
-      return true;
+      doubleOverlappedFrames.push(frameNumber);
+    } else if (hasSubOneSameFrame && !hasSubTwoSameFrame) {
+      subOneOverlappedFrames.push(frameNumber);
+    } else if (!hasSubOneSameFrame && hasSubTwoSameFrame) {
+      subTwoOverlappedFrames.push(frameNumber);
     }
-
-    return false;
-  });
-
-  const commonSubOne = subOneFrames.filter((imageNumber) => {
-    const hasMainSameFrame = mainFrames.includes(imageNumber);
-    const hasSubTwoSameFrame = subTwoFrames.includes(imageNumber);
-
-    return hasMainSameFrame && !hasSubTwoSameFrame;
-  });
-
-  const commonSubTwo = subTwoFrames.filter((imageNumber) => {
-    const hasMainSameFrame = mainFrames.includes(imageNumber);
-    const hasSubOneSameFrame = subOneFrames.includes(imageNumber);
-
-    return hasMainSameFrame && !hasSubOneSameFrame;
   });
 
   return {
     doubleOverlappedFrames,
-    subOneSingleShots: commonSubOne,
-    subTwoSingleShots: commonSubTwo,
+    subOneOverlappedFrames,
+    subTwoOverlappedFrames,
   };
 }
 

--- a/util/filterFramesByTwoSubs.js
+++ b/util/filterFramesByTwoSubs.js
@@ -1,6 +1,6 @@
 const validateArrays = require("./validateArrays");
 
-function sortCommonFrames(mainFrames, subOneFrames, subTwoFrames) {
+function filterFramesByTwoSubs(mainFrames, subOneFrames, subTwoFrames) {
   validateArrays(mainFrames, subOneFrames, subTwoFrames);
 
   const doubleOverlappedFrames = mainFrames.filter((imageNumber) => {
@@ -35,4 +35,4 @@ function sortCommonFrames(mainFrames, subOneFrames, subTwoFrames) {
   };
 }
 
-module.exports = sortCommonFrames;
+module.exports = filterFramesByTwoSubs;

--- a/util/getMatchedPercent.js
+++ b/util/getMatchedPercent.js
@@ -1,0 +1,23 @@
+const validateArrays = require("./validateArrays");
+
+const BLACK = 0;
+
+function getMatchedPercent(baseArray, comparisonArray) {
+  validateArrays(baseArray, comparisonArray);
+
+  if (baseArray.length !== comparisonArray.length) {
+    throw new Error("given Arrays have different length");
+  }
+
+  const matchedBlack = baseArray.reduce((blackSpots, spot, index) => {
+    if (spot === BLACK && comparisonArray[index] === BLACK) {
+      return blackSpots + 1;
+    }
+
+    return blackSpots;
+  }, 0);
+
+  return matchedBlack / baseArray.length;
+}
+
+module.exports = getMatchedPercent;

--- a/util/sortCommonFrames.js
+++ b/util/sortCommonFrames.js
@@ -1,0 +1,38 @@
+const validateArrays = require("./validateArrays");
+
+function sortCommonFrames(mainFrames, subOneFrames, subTwoFrames) {
+  validateArrays(mainFrames, subOneFrames, subTwoFrames);
+
+  const doubleOverlappedFrames = mainFrames.filter((imageNumber) => {
+    const hasSubOneSameFrame = subOneFrames.includes(imageNumber);
+    const hasSubTwoSameFrame = subTwoFrames.includes(imageNumber);
+
+    if (hasSubOneSameFrame && hasSubTwoSameFrame) {
+      return true;
+    }
+
+    return false;
+  });
+
+  const commonSubOne = subOneFrames.filter((imageNumber) => {
+    const hasMainSameFrame = mainFrames.includes(imageNumber);
+    const hasSubTwoSameFrame = subTwoFrames.includes(imageNumber);
+
+    return hasMainSameFrame && !hasSubTwoSameFrame;
+  });
+
+  const commonSubTwo = subTwoFrames.filter((imageNumber) => {
+    const hasMainSameFrame = mainFrames.includes(imageNumber);
+    const hasSubOneSameFrame = subOneFrames.includes(imageNumber);
+
+    return hasMainSameFrame && !hasSubOneSameFrame;
+  });
+
+  return {
+    doubleOverlappedFrames,
+    subOneSingleShots: commonSubOne,
+    subTwoSingleShots: commonSubTwo,
+  };
+}
+
+module.exports = sortCommonFrames;

--- a/util/validateArrays.js
+++ b/util/validateArrays.js
@@ -1,0 +1,7 @@
+function validateArrays(...arrays) {
+  if (!arrays.every(Array.isArray)) {
+    throw new Error("Arguments should be arrays");
+  }
+}
+
+module.exports = validateArrays;


### PR DESCRIPTION
# KanBan Title
- [원샷 프레임 분류 및 일치율 분석](https://minsug.notion.site/Server-compliations-POST-9792742043cd452da63beabb96c28746?pvs=4)

# Tasks in detail - checkList
- [x]  메인 - 서브1 일치율 비교
- [x]  메인 - 서브2 일치율 비교
- [x]  두 일치율을 비교하여 더 일치율이 높은 영상을 선택

# Description
- 원샷 알고리즘을 각 영상마다 진행한 후에 반환되는 배열을 받아 메인 프레임을 기준으로 서브 1과 2 프레임을 분류합니다. 만약 같은 시간대에 서브 1과 2 모두 원샷으로 판별된다면 일치율 비교를 통해 더 높은 일치율을 가진 프레임을 반환합니다. 일치율 분석은 움직임 분석을 기반으로 했으며 움직임이 없는 부분은 검은색으로 표현되는데 원샷 프레임의 모든 검은색을 확인하여 서브 프레임의 같은 index 픽셀에도 검은색인지 체크합니다. 

# Concern
- frame을 직접적으로 사용하는 `convertFrameToBinaryArray`만 `services`에 넣고 나머지는 `uti`에 넣었는데 이게 과연 합리적인지 판단부탁드립니다. 제 근거는 `frame`을 다루는 로직은 `services`에 `Index`와 숫자를 다루는 로직은 `util`애 넣는 것이 적합하다고 생각했습니다.

# Remarks
- 아직 컨트롤러가 구체적으로 어떤 매개변수를 받는지 몰라 임의로 설정했으며 추후 변경이 필요합니다. 
- `convertFrameToBinaryArray`애 path를 다루는 부분이 많은데 추후 수진님이 생성한 constants가 main으로 머지되면 업데이트가 필요합니다.

# 주의 사항
- [x] PR 크기는 300~500줄로 하되 최대 1000줄 미만으로 합니다.
- [x] conflict를 모두 해결하고 PR을 올려주세요


# PR 전 체크리스트
- [x] 가장 최신 브랜치를 pull 하였습니다
- [x] base 브랜치명을 확인하였습니다
- [x] 코드 컨벤션을 모두 확인하였습니다
- [x] 브랜치명을 확인하였습니다.
- [x] 작업 중 dependency 변경사항이 있는 경우 안내해주세요!