### PR TITLE
Feat. 교차구간 교체편집 컨트롤러 작성

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.4.1",
         "express": "~4.16.1",
+        "fluent-ffmpeg": "^2.1.2",
         "morgan": "~1.9.1",
         "multer": "^1.4.5-lts.1",
         "sharp": "^0.33.2",
@@ -2520,6 +2521,11 @@
       "dev": true,
       "peer": true
     },
+    "node_modules/async": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
+      "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg=="
+    },
     "node_modules/asynciterator.prototype": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/asynciterator.prototype/-/asynciterator.prototype-1.0.0.tgz",
@@ -4112,6 +4118,29 @@
       "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
       "dev": true
     },
+    "node_modules/fluent-ffmpeg": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/fluent-ffmpeg/-/fluent-ffmpeg-2.1.2.tgz",
+      "integrity": "sha512-IZTB4kq5GK0DPp7sGQ0q/BWurGHffRtQQwVkiqDgeO6wYJLLV5ZhgNOQ65loZxxuPMKZKZcICCUnaGtlxBiR0Q==",
+      "dependencies": {
+        "async": ">=0.2.9",
+        "which": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/fluent-ffmpeg/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -5041,8 +5070,7 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "node_modules/iterator.prototype": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.1",
     "express": "~4.16.1",
+    "fluent-ffmpeg": "^2.1.2",
     "morgan": "~1.9.1",
     "multer": "^1.4.5-lts.1",
     "sharp": "^0.33.2",

--- a/src/controllers/crossCutting.controller.js
+++ b/src/controllers/crossCutting.controller.js
@@ -69,7 +69,7 @@ async function crossCutting(req, res, next) {
 
   await exportFinalVideo();
 
-  res.status(200).send("success");
+  res.status(200).send({ result: "success", message: "final video exported" });
 }
 
 module.exports = crossCutting;

--- a/src/controllers/crossCutting.controller.js
+++ b/src/controllers/crossCutting.controller.js
@@ -1,0 +1,75 @@
+const stringifyImgPath = require("../util/stringifyImgPath");
+const editFrames = require("../services/editFrames");
+const exportFinalVideo = require("../services/exportFinalVideo");
+
+async function crossCutting(req, res, next) {
+  // const singleShots = res.locals.singleShots;
+  // const editPoints = res.locals.editPoints;
+  // const { subOneFrames, subTwoFrames } = await sortFrames(singleShots, editPoints);
+
+  // TODO: 잠시 Mock Data를 사용합니다. main 브랜치에 병합 전에 변경예정입니다.
+  const subOneFrames = {
+    1740: 3,
+    2190: 4,
+    2610: 4,
+    3690: 3,
+    4530: 2,
+  };
+  const subTwoFrames = {
+    90: 2,
+    330: 2,
+    450: 2,
+    570: 3,
+    840: 4,
+    1290: 3,
+    2910: 3,
+    3090: 4,
+    3300: 5,
+    4170: 4,
+    4350: 5,
+    6450: 2,
+  };
+
+  if (subOneFrames && subTwoFrames) {
+    const subOneFrameList = Object.entries(subOneFrames);
+    const subTwoFrameList = Object.entries(subTwoFrames);
+
+    if (subOneFrameList.length) {
+      const subOnePromiseList = subOneFrameList.map(
+        async ([frameNumber, durationTime]) => {
+          const mainFramePath = stringifyImgPath("main-contents", frameNumber);
+          const subFramePath = stringifyImgPath(
+            "sub-one-contents",
+            frameNumber,
+          );
+
+          await editFrames(mainFramePath, subFramePath, durationTime);
+        },
+      );
+
+      await Promise.all(subOnePromiseList);
+    }
+
+    if (subTwoFrameList.length) {
+      const subTwoPromiseList = subTwoFrameList.map(
+        async ([frameNumber, durationTime]) => {
+          const mainFramePath = stringifyImgPath("main-contents", frameNumber);
+          const subFramePath = stringifyImgPath(
+            "sub-two-contents",
+            frameNumber,
+          );
+
+          await editFrames(mainFramePath, subFramePath, durationTime);
+        },
+      );
+
+      await Promise.all(subTwoPromiseList);
+    }
+  }
+
+  await exportFinalVideo();
+
+  res.status(200).send("success");
+}
+
+module.exports = crossCutting;

--- a/src/services/applyDissolve.js
+++ b/src/services/applyDissolve.js
@@ -1,7 +1,9 @@
 const fs = require("fs").promises;
 const sharp = require("sharp");
 
-async function applyDissolve(previousFramePath, currentFramePath) {
+const stringifyImgPath = require("../util/stringifyImgPath");
+
+async function applyDissolveOneFrame(previousFramePath, currentFramePath) {
   const dissolvedBuffer = await sharp(previousFramePath)
     .modulate({ brightness: 0.9 })
     .composite([
@@ -14,6 +16,28 @@ async function applyDissolve(previousFramePath, currentFramePath) {
     .toBuffer();
 
   await fs.writeFile(currentFramePath, dissolvedBuffer);
+}
+
+function applyDissolve(frameNumber, subVideoLabel, DISSOLVE_FRAME) {
+  const dissolveList = new Array(DISSOLVE_FRAME).fill(0).map((_, index) => {
+    const mainFramePath = stringifyImgPath(
+      "main-contents",
+      frameNumber + index,
+    );
+    const subFramePath = stringifyImgPath(subVideoLabel, frameNumber + index);
+
+    return [mainFramePath, subFramePath];
+  });
+
+  const dissolvePromiseList = dissolveList.map(
+    async ([mainFramePath, subFramePath]) => {
+      await applyDissolveOneFrame(mainFramePath, subFramePath);
+
+      return subFramePath;
+    },
+  );
+
+  return dissolvePromiseList;
 }
 
 module.exports = applyDissolve;

--- a/src/services/applyTransition.js
+++ b/src/services/applyTransition.js
@@ -11,7 +11,6 @@ async function applyTransition(
   extractArguments,
   imgMetadata,
 ) {
-  const DISSOLVE_FRAME = 4;
   const { frameNumber, videoLabel: subVideoLabel } = parseImgPath(subImgPath);
   const resizeFramePathList = new Array(durationTime * 30)
     .fill(0)
@@ -39,28 +38,7 @@ async function applyTransition(
   );
 
   await Promise.all(resizePromiseList);
-
-  const dissolveStartList = new Array(DISSOLVE_FRAME)
-    .fill(0)
-    .map((_, index) => {
-      const mainFramePath = stringifyImgPath(
-        "main-contents",
-        frameNumber + index,
-      );
-      const subFramePath = stringifyImgPath(subVideoLabel, frameNumber + index);
-
-      return [mainFramePath, subFramePath];
-    });
-
-  const dissolveStartPromiseList = dissolveStartList.map(
-    async ([mainFramePath, subFramePath]) => {
-      await applyDissolve(mainFramePath, subFramePath);
-
-      return subFramePath;
-    },
-  );
-
-  await Promise.all(dissolveStartPromiseList);
+  await Promise.all(applyDissolve(frameNumber, subVideoLabel, 2));
 
   const replaceFramesPromiseList = resizeFramePathList.map(
     async ([mainFramePath, subFramePath]) => {

--- a/src/services/applyTransition.js
+++ b/src/services/applyTransition.js
@@ -10,6 +10,7 @@ async function applyTransition(
   durationTime,
   extractArguments,
   imgMetadata,
+  DISSOLVE_FRAME,
 ) {
   const { frameNumber, videoLabel: subVideoLabel } = parseImgPath(subImgPath);
   const resizeFramePathList = new Array(durationTime * 30)
@@ -38,7 +39,12 @@ async function applyTransition(
   );
 
   await Promise.all(resizePromiseList);
-  await Promise.all(applyDissolve(frameNumber, subVideoLabel, 2));
+
+  if (DISSOLVE_FRAME) {
+    await Promise.all(
+      applyDissolve(frameNumber, subVideoLabel, DISSOLVE_FRAME),
+    );
+  }
 
   const replaceFramesPromiseList = resizeFramePathList.map(
     async ([mainFramePath, subFramePath]) => {

--- a/src/services/editFrames.js
+++ b/src/services/editFrames.js
@@ -113,6 +113,8 @@ function isSamePositionFace(mainCoord, subCoord, imgMetadata) {
 
 async function editFrames(mainImg, subImg, durationTime) {
   try {
+    const DISSOLVE_FRAME = durationTime > 3 ? 2 : 0;
+
     const mainFaceData = await detectFace(mainImg);
     const subFaceData = await detectFace(subImg);
     const { frameNumber, videoLabel: subVideoLabel } = parseImgPath(subImg);
@@ -122,7 +124,12 @@ async function editFrames(mainImg, subImg, durationTime) {
     if (isNotExistFaceImg) {
       console.log("조회된 얼굴이 없습니다.");
 
-      await Promise.all(applyDissolve(frameNumber, subVideoLabel, 1));
+      if (DISSOLVE_FRAME) {
+        await Promise.all(
+          applyDissolve(frameNumber, subVideoLabel, DISSOLVE_FRAME),
+        );
+      }
+
       await Promise.all(replaceFrames(subImg, durationTime));
 
       return;
@@ -135,7 +142,12 @@ async function editFrames(mainImg, subImg, durationTime) {
     if (!isSamePositionFace(mainFaceCoord, subFaceCoord, imgMetadata)) {
       console.log("같은 위치의 얼굴이 아닙니다.");
 
-      await Promise.all(applyDissolve(frameNumber, subVideoLabel, 1));
+      if (DISSOLVE_FRAME) {
+        await Promise.all(
+          applyDissolve(frameNumber, subVideoLabel, DISSOLVE_FRAME),
+        );
+      }
+
       await Promise.all(replaceFrames(subImg, durationTime));
 
       return;
@@ -147,7 +159,13 @@ async function editFrames(mainImg, subImg, durationTime) {
       imgMetadata,
     );
 
-    await applyTransition(subImg, durationTime, extractArguments, imgMetadata);
+    await applyTransition(
+      subImg,
+      durationTime,
+      extractArguments,
+      imgMetadata,
+      DISSOLVE_FRAME,
+    );
   } catch (faceDetectError) {
     console.error(`얼굴 좌표 연산 중 에러 발생 ${faceDetectError}`);
   }

--- a/src/services/editFrames.js
+++ b/src/services/editFrames.js
@@ -122,8 +122,6 @@ async function editFrames(mainImg, subImg, durationTime) {
       !mainFaceData.predictions.length || !subFaceData.predictions.length;
 
     if (isNotExistFaceImg) {
-      console.log("조회된 얼굴이 없습니다.");
-
       if (DISSOLVE_FRAME) {
         await Promise.all(
           applyDissolve(frameNumber, subVideoLabel, DISSOLVE_FRAME),
@@ -140,8 +138,6 @@ async function editFrames(mainImg, subImg, durationTime) {
     const imgMetadata = await sharp(mainImg).metadata();
 
     if (!isSamePositionFace(mainFaceCoord, subFaceCoord, imgMetadata)) {
-      console.log("같은 위치의 얼굴이 아닙니다.");
-
       if (DISSOLVE_FRAME) {
         await Promise.all(
           applyDissolve(frameNumber, subVideoLabel, DISSOLVE_FRAME),

--- a/src/services/editFrames.js
+++ b/src/services/editFrames.js
@@ -1,5 +1,6 @@
 const sharp = require("sharp");
 
+const parseImgPath = require("../util/parseImgPath");
 const detectFace = require("./detectFace");
 const applyTransition = require("./applyTransition");
 const applyDissolve = require("./applyDissolve");
@@ -114,13 +115,14 @@ async function editFrames(mainImg, subImg, durationTime) {
   try {
     const mainFaceData = await detectFace(mainImg);
     const subFaceData = await detectFace(subImg);
+    const { frameNumber, videoLabel: subVideoLabel } = parseImgPath(subImg);
     const isNotExistFaceImg =
       !mainFaceData.predictions.length || !subFaceData.predictions.length;
 
     if (isNotExistFaceImg) {
       console.log("조회된 얼굴이 없습니다.");
 
-      await applyDissolve(mainImg, subImg);
+      await Promise.all(applyDissolve(frameNumber, subVideoLabel, 1));
       await Promise.all(replaceFrames(subImg, durationTime));
 
       return;
@@ -133,7 +135,7 @@ async function editFrames(mainImg, subImg, durationTime) {
     if (!isSamePositionFace(mainFaceCoord, subFaceCoord, imgMetadata)) {
       console.log("같은 위치의 얼굴이 아닙니다.");
 
-      await applyDissolve(mainImg, subImg);
+      await Promise.all(applyDissolve(frameNumber, subVideoLabel, 1));
       await Promise.all(replaceFrames(subImg, durationTime));
 
       return;

--- a/src/services/exportFinalVideo.js
+++ b/src/services/exportFinalVideo.js
@@ -18,6 +18,7 @@ function exportFinalVideo() {
       TEMP_DIR_FRAMES.MAIN,
       "frame_30fps_%d.jpg",
     );
+    const SCALE = "1280: 720";
 
     ffmpeg()
       .input(inputVideoPattern)
@@ -27,7 +28,7 @@ function exportFinalVideo() {
       .videoCodec("libx264")
       .outputOptions([
         "-pix_fmt yuv420p",
-        "-vf scale=1280:720",
+        `-vf scale=${SCALE}`,
         "-crf 23",
         "-b:a 128k",
       ])

--- a/src/services/exportFinalVideo.js
+++ b/src/services/exportFinalVideo.js
@@ -1,0 +1,48 @@
+const path = require("path");
+const ffmpeg = require("fluent-ffmpeg");
+
+const {
+  TEMP_DIR_FRAMES,
+  TEMP_DIR_WAV_ADJUSTED,
+  TEMP_DIR_VIDEOS,
+} = require("../constants/paths");
+
+function exportFinalVideo() {
+  return new Promise((resolve, reject) => {
+    const finalVideoPath = path.join(TEMP_DIR_VIDEOS.FOLDER, "finalVideo.mp4");
+    const finalAudioPath = path.join(
+      TEMP_DIR_WAV_ADJUSTED.MAIN,
+      "main-audio.wav",
+    );
+    const inputVideoPattern = path.join(
+      TEMP_DIR_FRAMES.MAIN,
+      "frame_30fps_%d.jpg",
+    );
+
+    ffmpeg()
+      .input(inputVideoPattern)
+      .inputFPS(30)
+      .inputFormat("image2")
+      .input(finalAudioPath)
+      .videoCodec("libx264")
+      .outputOptions([
+        "-pix_fmt yuv420p",
+        "-vf scale=1280:720",
+        "-crf 23",
+        "-b:a 128k",
+      ])
+      .on("end", () => {
+        console.log("최종 비디오가 편집 완료되었습니다.");
+
+        resolve();
+      })
+      .on("error", (err) => {
+        console.error(`에러발생 ${err}`);
+
+        reject();
+      })
+      .save(finalVideoPath);
+  });
+}
+
+module.exports = exportFinalVideo;


### PR DESCRIPTION
# KanBan Title
- [서브 영상 편집 프레임 교체 및 영상전환](https://www.notion.so/minsug/Server-compliations-POST-b06eaf74e03e4c5e93c663c4f2ecaef2?pvs=4)

# Tasks in detail - checkList
- [x]  `duration time` 에 따른 교차가 완료된 영상을 `main-contents` 폴더에 모두 취합합니다.
- [x]  `ffmpeg`을 이용하여 *.mp4* 영상으로 반환합니다.
- [x]  **PoC**를 통해 알아낸 방법으로 진행하고 성능을 확인합니다.
- [x] 최종 영상을 반환합니다.

# Description
- 교체 편집 프로세스를 모두 끝낸 프레임 이미지들을 모두 mp4 영상으로 반환하는 작업입니다.
- 별개로 작업하던 프레임 이미지, 영상, 오디오를 모두 인코딩/디코딩 하여 반환합니다.
- 최종 작업물을 반환하는 작업입니다.

# Concern
- 프레임을 영상으로 변환하여 저장 시에, 프레임을 downgrade 하지 않으면 용량이 지나치게 커지는 현상이 있었습니다. 민석님, 민지님 도움을 받아 스펙 조정 진행하였습니다. (1920:1080 에서 1280:720)
- fluent-ffmpeg을 통해 여러개의 프레임을 합치는 작업을 진행하였으나, 추후 ffmpeg으로 재작업하고자 합니다. (성능 이슈로 인해 우선은 라이브러리를 도입하였습니다.)

# remarks
- ffmpeg을 node.js 환경에서 안전하게 사용하게 해주는 라이브러리인 `fluent-ffmpeg`을 설치하였습니다.

# 주의 사항
- [x] PR 크기는 300~500줄로 하되 최대 1000줄 미만으로 합니다.
- [x] conflict를 모두 해결하고 PR을 올려주세요


# PR 전 체크리스트

- [x] 가장 최신 브랜치를 pull 하였습니다 | 최신 브랜치 커밋을 기다리는 중입니다..
- [x] base 브랜치명을 확인하였습니다
- [x] 코드 컨벤션을 모두 확인하였습니다
- [x] 브랜치명을 확인하였습니다.
- [x] 작업 중 dependency 변경사항이 있는 경우 안내해주세요!