### PR TITLE
Feat. 세로영상 편집구간 추출 로직 및 미들웨어 구현 

### DIFF
--- a/src/middlewares/findVerticalEditPoints.js
+++ b/src/middlewares/findVerticalEditPoints.js
@@ -1,0 +1,78 @@
+/* eslint-disable no-await-in-loop */
+const path = require("path");
+const fs = require("fs").promises;
+const sharp = require("sharp");
+
+const select1fpsFrames = require("../util/select1fpsFrames");
+const analyzeVerticalDuration = require("../services/analyzeVerticalDuration");
+const detectVerticalSingleShots = require("../services/detectVerticalSingleShots");
+const detectVerticalMovement = require("../services/detectVerticalMovement");
+const progressStatus = require("../routes/progressStatus");
+
+const { TEMP_DIR_FRAMES } = require("../constants/paths");
+
+async function findVerticalEditPoints(req, res, next) {
+  const { videoCount } = res.locals;
+  const folderList =
+    videoCount === 2
+      ? ["main-contents", "sub-one-contents"]
+      : ["main-contents", "sub-one-contents", "sub-two-contents"];
+
+  let editPoints = {};
+  const singleShots = {};
+
+  progressStatus.stage = "editpoints";
+
+  for (let videoType = 0; videoType < folderList.length; videoType += 1) {
+    const folderName = folderList[videoType];
+    const currentFrameDirectory = path.join(TEMP_DIR_FRAMES.FOLDER, folderName);
+    const currentFrameFiles = await fs.readdir(currentFrameDirectory);
+    const currentFramePathList = currentFrameFiles.map((frameName) =>
+      path.join(currentFrameDirectory, frameName),
+    );
+
+    currentFramePathList.sort((a, b) => {
+      const currentFramePath = parseInt(path.basename(a).split("_").pop(), 10);
+      const nextFramePath = parseInt(path.basename(b).split("_").pop(), 10);
+
+      return currentFramePath - nextFramePath;
+    });
+
+    const filtered1fpsPathList = select1fpsFrames(currentFramePathList);
+
+    const metadata = await sharp(filtered1fpsPathList[0]).metadata();
+    const { width } = metadata;
+    const dividedByThree = Math.floor(width / 3);
+    const LOW_FRAME_WIDTH = dividedByThree - 10;
+    const LOW_FRAME_HEIGHT = metadata.height;
+
+    const movementRatioOfAllFrames = await detectVerticalMovement(
+      filtered1fpsPathList,
+      folderName,
+      LOW_FRAME_WIDTH,
+      LOW_FRAME_HEIGHT,
+    );
+
+    const [singleShotFrameList, nonSelectedFramesMovementAvg] =
+      detectVerticalSingleShots(movementRatioOfAllFrames);
+
+    if (folderName === "main-contents") {
+      const mainSingleShotEditDuration = await analyzeVerticalDuration(
+        singleShotFrameList,
+        movementRatioOfAllFrames,
+        nonSelectedFramesMovementAvg,
+      );
+
+      editPoints = mainSingleShotEditDuration;
+    }
+
+    singleShots[folderName] = singleShotFrameList;
+  }
+
+  res.locals.editPoints = editPoints;
+  res.locals.singleShots = singleShots;
+
+  next();
+}
+
+module.exports = findVerticalEditPoints;

--- a/src/routes/compilations.js
+++ b/src/routes/compilations.js
@@ -6,9 +6,20 @@ const progressStatus = require("./progressStatus");
 
 const extractFrames = require("../middlewares/extractFrames");
 const findEditPoints = require("../middlewares/findEditPoints");
+const findVerticalEditPoints = require("../middlewares/findVerticalEditPoints");
 const crossCuttingController = require("../controllers/crossCutting.controller");
 
 router.post("/", extractFrames, findEditPoints, crossCuttingController);
+
+// TODO. 세로영상의 경우 새롭게 엔드포인트를 생성하고 컨트롤러를 수정해야합니다.
+// TODO. 아래는 세로 영상 mockup을 위한 컨트롤러 형태입니다.
+/* router.post(
+  "/",
+  extractFrames,
+  // findEditPoints,
+  findVerticalEditPoints,
+  crossCuttingController
+); */
 
 router.get("/", (req, res) => {
   res.status(200).json(progressStatus.stage);

--- a/src/services/analyzeVerticalDuration.js
+++ b/src/services/analyzeVerticalDuration.js
@@ -1,0 +1,66 @@
+const path = require("path");
+const fs = require("fs").promises;
+
+const select1fpsFrames = require("../util/select1fpsFrames");
+const { TEMP_DIR_FRAMES } = require("../constants/paths");
+
+const MOVEMENT_THRESHOLD = 0.09;
+
+async function analyzeVerticalDuration(
+  singleShotFrameList,
+  movementResults,
+  nonSelectedFramesMovementAvg,
+) {
+  const mainFrameFileList = await fs.readdir(TEMP_DIR_FRAMES.MAIN);
+  const mainFramePathList = mainFrameFileList.map((frame) =>
+    path.join(TEMP_DIR_FRAMES.MAIN, frame),
+  );
+
+  mainFramePathList.sort((a, b) => {
+    const currentFramePath = parseInt(path.basename(a).split("_").pop(), 10);
+    const nextFramePath = parseInt(path.basename(b).split("_").pop(), 10);
+
+    return currentFramePath - nextFramePath;
+  });
+
+  const filtered1fpsFramePathList = select1fpsFrames(mainFramePathList);
+
+  const replacementDuration = {};
+
+  for (
+    let singleShotIndex = 0;
+    singleShotIndex < singleShotFrameList.length - 1;
+    singleShotIndex += 1
+  ) {
+    let duration = 1;
+    const currentSingleShotPath = singleShotFrameList[singleShotIndex];
+    const nextSingleShotpath = singleShotFrameList[singleShotIndex + 1];
+
+    const currentSingleShotIndex = filtered1fpsFramePathList.findIndex(
+      (framePath) => framePath === currentSingleShotPath,
+    );
+    const nextSingleShotIndex = filtered1fpsFramePathList.findIndex(
+      (framePath) => framePath === nextSingleShotpath,
+    );
+
+    for (
+      let nextFrame = currentSingleShotIndex + 1;
+      nextFrame < nextSingleShotIndex;
+      nextFrame += 1
+    ) {
+      const { movementRatio } = movementResults[nextFrame];
+
+      if (movementRatio < nonSelectedFramesMovementAvg) {
+        break;
+      }
+
+      duration += 1;
+    }
+
+    replacementDuration[currentSingleShotPath] = duration;
+  }
+
+  return replacementDuration;
+}
+
+module.exports = analyzeVerticalDuration;

--- a/src/services/detectVerticalMovement.js
+++ b/src/services/detectVerticalMovement.js
@@ -1,0 +1,79 @@
+/* eslint-disable no-await-in-loop */
+const path = require("path");
+const sharp = require("sharp");
+
+const ensureDir = require("../util/ensureDir");
+const analyzeMovementRatio = require("./analyzeMovementRatio");
+
+async function detectVerticalMovement(
+  filteredFramePathList,
+  folderName,
+  resizedWidth,
+  resizedHeight,
+) {
+  const outputFileDirectory = path.join(
+    __dirname,
+    `../temp/difference/${folderName}`,
+  );
+
+  await ensureDir(outputFileDirectory);
+
+  const detectedMovementRatioList = [];
+
+  for (
+    let indexOf1fps = 0;
+    indexOf1fps < filteredFramePathList.length - 1;
+    indexOf1fps += 1
+  ) {
+    const currentFramePath = filteredFramePathList[indexOf1fps];
+    const nextFramePath = filteredFramePathList[indexOf1fps + 1];
+    const frameNumber = parseInt(
+      path.basename(currentFramePath).split("_").pop(),
+      10,
+    );
+
+    const outputFileName = `difference_${frameNumber}.jpg`;
+    const outputPath = path.join(outputFileDirectory, outputFileName);
+
+    const currentLowFrame = sharp(currentFramePath)
+      .resize(resizedWidth, resizedHeight)
+      .modulate({ saturation: 0.1 })
+      .modulate({ brightness: 2.0 });
+
+    const nextLowFrame = sharp(nextFramePath)
+      .resize(resizedWidth, resizedHeight)
+      .modulate({ saturation: 0.1 })
+      .modulate({ brightness: 2.0 });
+
+    const resultOfDifference = await currentLowFrame
+      .composite([
+        { input: await nextLowFrame.toBuffer(), blend: "difference" },
+      ])
+      .modulate({ saturation: 3.0 })
+      .toColourspace("b-w")
+      .toBuffer();
+
+    const { data, info } = await sharp(resultOfDifference)
+      .raw()
+      .toBuffer({ resolveWithObject: true });
+
+    await sharp(data, {
+      raw: {
+        width: info.width,
+        height: info.height,
+        channels: info.channels,
+      },
+    }).toFile(outputPath);
+
+    const resultOfMovementRatio = await analyzeMovementRatio(outputPath);
+
+    detectedMovementRatioList.push({
+      path: currentFramePath,
+      movementRatio: resultOfMovementRatio,
+    });
+  }
+
+  return detectedMovementRatioList;
+}
+
+module.exports = detectVerticalMovement;

--- a/src/services/detectVerticalSingleShots.js
+++ b/src/services/detectVerticalSingleShots.js
@@ -1,0 +1,33 @@
+function detectVerticalSingleShots(movementRatioList) {
+  const movementRatioFrames = movementRatioList.map((frameMovementInfo) => {
+    return frameMovementInfo.movementRatio;
+  });
+
+  const normalizedMovementRatioList = movementRatioFrames.slice(0, -10);
+  const movementRatioAvg =
+    normalizedMovementRatioList.reduce((acc, cur) => acc + cur, 0) /
+    normalizedMovementRatioList.length;
+
+  const underAverageMovementList = normalizedMovementRatioList.filter(
+    (movementRatio) => movementRatio < movementRatioAvg,
+  );
+  const nonSelectedFramesMovementAvg =
+    underAverageMovementList.reduce((acc, cur) => acc + cur, 0) /
+    underAverageMovementList.length;
+
+  const singleShotList = [];
+
+  for (let i = 0; i < movementRatioList.length; i += 1) {
+    const movementResult = movementRatioList[i];
+
+    if (movementResult.movementRatio >= movementRatioAvg) {
+      singleShotList.push(movementResult.path);
+    }
+  }
+
+  console.log("singleShot list is extracted successfully");
+
+  return [singleShotList, nonSelectedFramesMovementAvg];
+}
+
+module.exports = detectVerticalSingleShots;

--- a/src/services/extractFramesFromVideo.js
+++ b/src/services/extractFramesFromVideo.js
@@ -8,7 +8,7 @@ async function extractFramesFromVideo(inputPath, framePath, startSecond) {
       "-i",
       inputPath,
       "-vf",
-      "fps=30, scale=1920x1080",
+      "fps=30",
       "-ss",
       startSecond,
       "-q:v",


### PR DESCRIPTION
# KanBan Title
- [[app + web] 세로영상 편집구간 추출 로직 및 미들웨어 구현](https://www.notion.so/minsug/server-06e781bcab24414da8e62ee702158afd?pvs=4)

# Tasks in detail - checkList
- [x] 세로영상의 움직임 탐지 로직 구현
- [x] 세로영상 편집지점 추출 로직 구현
- [x] 세로영상 편집 지속시간 추출 로직 구현
- [x] 세로영상 편집구간 미들웨어 구현

# Description
- 기존 가로 영상에 대해서만 지원하던 서비스를 app개발로 인해 세로영상까지 서비스를 확대함에 따라 
   세로 영상의 편집구간 추출 로직들과 미들웨어를 별도로 구현하였습니다. 

- 세로 영상의 경우 직캠영상으로 한 명의 가수에 해당하기 때문에 움직임의 분석으로만 이루어집니다. (얼굴분석X)

# remarks
- app과의 연결이 필요합니다.
- 세로영상에 대한 엔드포인트 생성이 필요할 수 있습니다.

# 주의 사항
- [] PR 크기는 300~500줄로 하되 최대 1000줄 미만으로 합니다.
- [] conflict를 모두 해결하고 PR을 올려주세요


# PR 전 체크리스트
- [] 가장 최신 브랜치를 pull 하였습니다
- [] base 브랜치명을 확인하였습니다
- [] 코드 컨벤션을 모두 확인하였습니다
- [] 브랜치명을 확인하였습니다.
- [] 작업 중 dependency 변경사항이 있는 경우 안내해주세요!